### PR TITLE
Letsencrypt depends on nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
   letsencrypt:
     image: jrcs/letsencrypt-nginx-proxy-companion:latest
     restart: always
+    depends_on:
+      - nginx-proxy
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /apps/docker-articles/nginx/vhost.d:/etc/nginx/vhost.d


### PR DESCRIPTION
I ran into `Error: can't get nginx-proxy container id` when using docker-compose and was able to fix the problem by adding depends_on under letsencrypt.